### PR TITLE
Add docs/README.md — README, project management processes summary, and links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+```markdown
+# OctoAcme Project Management Docs
+
+Welcome to the OctoAcme project management documentation. This centralized README summarizes how we run projects at OctoAcme and links to detailed process guides in this folder.
+
+OctoAcme follows a structured, iterative delivery approach. Work starts with a lightweight initiation (Project One-pager) to confirm the problem, success metrics, stakeholders, and a high-level timeline, then moves into planning where the team breaks work into prioritized backlog items with acceptance criteria and estimates. Execution is cadence-driven — teams use a project board (Backlog → Ready → In Progress → In Review → QA → Done), a Definition of Done, and short iterations to deliver small, testable increments. Releases and deployments follow checklist-driven steps with rollback plans and post-deploy verification, and every project concludes with a retrospective to capture learnings and continuous improvements.
+
+Roles and responsibilities are explicit to ensure clear ownership: Project Managers coordinate delivery, schedules, and communication; Product Managers own outcomes and prioritization; Developers implement and test; QA validates acceptance criteria; and stakeholders provide inputs and approvals. Key artifacts — Project One-pager, roadmap and release plan, backlog with acceptance criteria, risk register, and retrospective action items — live in this repo’s docs and should be kept up to date as the project evolves.
+
+Communication is rhythm-based and templated: daily standups for the delivery team, weekly PM+PdM syncs, weekly delivery syncs for cross-team updates and risk review, and monthly stakeholder updates. Quality assurance is built into the workflow: pull requests include acceptance criteria, automated tests and security scans run in CI, at least one review is required before merge, and releases require pre-release checks, staging smoke tests, and post-deploy verification. For incidents, follow the incident playbook and run a blameless retrospective afterward.
+
+## Documentation Index
+- [Project Management Overview](docs/octoacme-project-management-overview.md)
+- [Project Initiation Guide](docs/octoacme-project-initiation.md)
+- [Project Planning](docs/octoacme-project-planning.md)
+- [Execution & Tracking](docs/octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](docs/octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](docs/octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](docs/octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](docs/octoacme-roles-and-personas.md)
+
+## How to use this README
+- Link this README from your project README or project board so it’s discoverable as the single source of truth for project processes.
+- Keep the linked docs updated as processes evolve. Add new process docs by following the repository’s docs/ conventions and the ".github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml" template for changes.
+```


### PR DESCRIPTION
Adds a centralized README for OctoAcme project management docs. Related to issue #2