### PR TITLE
Improve process docs — add new personas and practical checklists

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -1,3 +1,4 @@
+```markdown
 # OctoAcme Personas
 
 This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.
@@ -75,7 +76,104 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
-## How these personas are used in the exercise
-- Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
-- Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
+## QA / Testing
 
+### Role Summary
+QA ensures that delivered work meets acceptance criteria and quality standards through testing and verification.
+
+### Responsibilities
+- Define testing approaches for features and releases
+- Execute manual tests when necessary and verify automated test coverage
+- Collaborate with developers to reproduce and triage issues
+- Validate release readiness and sign-off on acceptance criteria
+
+### Typical Communication
+- QA reports during weekly delivery syncs
+- Test status in PRs and release docs
+
+---
+
+## Stakeholders
+
+Represent business groups, customers, or partners who provide inputs, priorities, and approvals for project work.
+
+---
+
+## Additional Personas (Proposed additions)
+
+These roles are commonly involved in cross-functional delivery but were previously underspecified. Adding them clarifies accountability and improves handoffs.
+
+### UX / UI Designer
+
+- Role Summary:
+  Design usable, accessible experiences that meet product goals and stakeholder needs.
+- Responsibilities:
+  - Create user flows, wireframes, high-fidelity mockups, and interactive prototypes.
+  - Conduct usability reviews and accessibility checks.
+  - Provide design acceptance criteria and QA guidance for visual/UX behavior.
+  - Participate in product discovery and user research.
+- Interaction:
+  - Works with Product Managers to translate requirements into designs.
+  - Handoffs assets and specifications to Developers; reviews implementations in PRs.
+  - Contributes to acceptance criteria and demo materials.
+
+### DevOps / Platform Engineer
+
+- Role Summary:
+  Build and maintain automated delivery pipelines, environments, observability, and platform security.
+- Responsibilities:
+  - Design and operate CI/CD pipelines and infrastructure-as-code.
+  - Configure monitoring, alerts, and runbooks for production systems.
+  - Automate staging and deployment processes; manage secrets and access controls.
+  - Support incident response and post-incident remediation.
+- Interaction:
+  - Works with Developers to enable safe, repeatable deployments.
+  - Coordinates with QA to provide test environments and automation resources.
+  - Escalates production-level risks to PM/Project stakeholders.
+
+### Data Analyst / Analytics Engineer
+
+- Role Summary:
+  Provide data-driven insights to measure product outcomes and validate success metrics.
+- Responsibilities:
+  - Define and instrument metrics and events required to validate hypotheses.
+  - Build dashboards and reports for stakeholders and PMs.
+  - Analyze experiments and feature performance; surface actionable insights.
+  - Validate data quality and collaborate on migration/ETL considerations.
+- Interaction:
+  - Works with Product Managers to define success metrics.
+  - Partners with Developers and DevOps to ensure correct data pipelines.
+  - Shares findings in weekly delivery syncs and retrospectives.
+
+### Customer Support Lead (or Support Engineer)
+
+- Role Summary:
+  Act as the front line for user-reported issues, escalate incidents, and feed user insights back to product and engineering.
+- Responsibilities:
+  - Triage incoming support tickets and create reproducible issues.
+  - Maintain knowledge base and FAQs relevant to releases.
+  - Own communication with affected users during incidents and planned changes.
+  - Provide user-impact data and trends to the product team.
+- Interaction:
+  - Communicates major incidents and recurring user pain points to PMs and Project Managers.
+  - Works with Developers for reproductions and fixes; with QA for post-fix verification.
+  - Participates in post-incident reviews and retrospectives.
+
+---
+
+## How these personas interact (high-level)
+
+- Product Manager defines the why and success metrics; UX designs the how; Developers and QA implement and verify; Project Manager coordinates schedules and communication; DevOps ensures the path to production is safe and observable; Data Analyst validates outcomes; Support keeps the team grounded in user-reported realities.
+- Suggested RACI examples:
+  - Acceptance criteria: Responsible (PdM), Accountable (PdM), Consulted (UX, Dev), Informed (PM, Stakeholders)
+  - Release readiness: Responsible (Dev/QA), Accountable (PM), Consulted (DevOps, PdM), Informed (Support, Stakeholders)
+  - Incident communications: Responsible (Support), Accountable (PM), Consulted (DevOps, Dev), Informed (PdM, Sponsor)
+
+---
+
+## Using these persona definitions
+
+- Keep role descriptions short and action-oriented.
+- When starting a project, list named individuals for each applicable role on the Project One-pager.
+- Use these definitions to create clear handoffs and reduce ambiguity about ownership.
+```

--- a/docs/pr-checklist.md
+++ b/docs/pr-checklist.md
@@ -1,0 +1,26 @@
+```markdown
+# Pull Request Checklist (OctoAcme)
+
+Use this checklist on all feature/change PRs to improve review speed and release readiness.
+
+- [ ] Link to related issue(s) and the project one-pager (if relevant)
+- [ ] Include clear acceptance criteria in the PR description
+- [ ] Keep PRs small and focused (aim <= 400 lines of changes)
+- [ ] Automated tests added/updated and all CI checks pass
+- [ ] Security and linting scans pass
+- [ ] Add testing instructions / reproduction steps in the PR body
+- [ ] Update docs or changelog when behavior changes
+- [ ] Assign reviewers and set expected review context (what to look for)
+- [ ] Mark the PR with the appropriate labels (e.g., bug, feature, docs)
+- [ ] If the change impacts UX, attach screenshots or a short demo video
+- [ ] Confirm whether this requires a migration or release note
+
+Reviewer guidance:
+- Verify acceptance criteria are testable.
+- Run the provided testing steps or smoke tests when needed.
+- Check for adequate automated test coverage for new logic.
+
+Merge rules:
+- At least one required approval (or team-defined approval policy) and all CI checks successful.
+- For larger or riskier changes, consider an additional reviewer from a dependent team.
+```

--- a/docs/project-onboarding.md
+++ b/docs/project-onboarding.md
@@ -1,0 +1,14 @@
+```markdown
+# Project Onboarding Checklist
+
+When a project starts, run through this checklist to ensure the team has what they need.
+
+- [ ] Complete Project One-pager and add to docs/
+- [ ] Create project board and backlog skeleton
+- [ ] List named owners for core roles (PM, PdM, Dev lead, QA, DevOps, UX, Support, Data)
+- [ ] Add communication channels and meeting cadence to the one-pager
+- [ ] Document success metrics and dashboards to monitor
+- [ ] Ensure CI and test environments are configured
+- [ ] Add initial risk register entry and owner
+- [ ] Share onboarding doc and run a short walkthrough with the delivery team
+```

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,36 @@
+```markdown
+# Release & Deployment Checklist (OctoAcme)
+
+Standard checklist to reduce risk and improve release quality.
+
+Pre-release
+- [ ] All acceptance criteria met for planned items
+- [ ] All PRs merged, CI green, and security scans passed
+- [ ] Release notes drafted and owner assigned
+- [ ] Rollback/mitigation plan documented
+- [ ] Stakeholders and support notified of upcoming release
+- [ ] Staging environment smoke tests prepared and owner assigned
+
+Staging verification
+- [ ] Deploy to staging via CI/CD pipeline
+- [ ] Run automated smoke tests and manual verification for critical flows
+- [ ] Verify metrics and alerts are functioning as expected
+- [ ] Sign-off from QA and PM for production rollout
+
+Production deploy
+- [ ] Deployment window scheduled (if applicable)
+- [ ] Backup/snapshot created if applicable
+- [ ] Production deploy via automated pipeline
+- [ ] Post-deploy verification steps executed (monitoring, smoke tests)
+- [ ] Announce release to stakeholders and support channel
+
+Post-release
+- [ ] Monitor for regressions and critical alerts for at least N hours (define per release)
+- [ ] Open follow-up tasks for cleanup or improvements discovered in the release
+- [ ] Run a short retrospective if the release had incidents or was high-risk
+
+Incident response (if needed)
+- [ ] Trigger incident runbook and notify on-call
+- [ ] Escalate per the project's escalation path
+- [ ] Record timeline, RCA, and action items; add to retrospective
+```


### PR DESCRIPTION
Adds new personas (UX, DevOps, Data, Support) to docs/octoacme-roles-and-personas.md and introduces PR, release, and onboarding checklists to improve handoffs and reduce process gaps.
Closes #4